### PR TITLE
adds cfg option for URI encryption mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -120,6 +120,8 @@ type Config struct {
 	EncryptIpcipher bool `config:"encrypt_ipcipher"`
 	// are the URIs encrypted?
 	EncryptURIs bool `config:"encrypt_uris"`
+	// is AES CBC mode used for URIs encryption?
+	EncryptCbcURI bool `config:"encrypt_cbc_uri"`
 	// are the CallIDs encrypted?
 	EncryptCallIDs bool `config:"encrypt_call_ids"`
 	// are the UA and UAS encrypted?
@@ -200,6 +202,10 @@ func (cfg Config) UseAnonymization() bool {
 
 func (cfg Config) UseIpcipher() bool {
 	return cfg.EncryptIpcipher
+}
+
+func (cfg Config) UseCbcURI() bool {
+	return cfg.EncryptCbcURI
 }
 
 var DefaultMaxRates = calltr.EvRateMaxes{

--- a/config.go
+++ b/config.go
@@ -173,6 +173,7 @@ var defaultConfigVals = Config{
 	EncryptIPs:        false,
 	EncryptIpcipher:   false,
 	EncryptURIs:       false,
+	EncryptCbcURI:     false,
 	EncryptCallIDs:    false,
 	EncryptUA:         false,
 }


### PR DESCRIPTION
- by default URIs should be anonymized using prefix preserving mode
- "encrypt_cbc_uri" cfg option enforces AES CBC (non prefix preserving mode) for
  URI anonymization